### PR TITLE
Investigate property availability booking discrepancy

### DIFF
--- a/src/components/CalendarManagement/AdvancedCalendarManager.tsx
+++ b/src/components/CalendarManagement/AdvancedCalendarManager.tsx
@@ -30,8 +30,8 @@ type Booking = {
   id: string;
   guest_id: string;
   guest_name?: string;
-  start_date: string;
-  end_date: string;
+  check_in: string;
+  check_out: string;
   status: 'pendiente' | 'confirmada' | 'cancelada';
   created_at: string;
 };
@@ -106,8 +106,8 @@ const AdvancedCalendarManager: React.FC<AdvancedCalendarManagerProps> = ({
         .select(`
           id, 
           guest_id, 
-          start_date, 
-          end_date, 
+          check_in, 
+          check_out, 
           status, 
           created_at,
           guests!inner(users!inner(full_name))
@@ -171,7 +171,7 @@ const AdvancedCalendarManager: React.FC<AdvancedCalendarManagerProps> = ({
 
   const getBooking = (date: Date) => {
     const d = date.toISOString().slice(0, 10);
-    return bookings.find(b => b.start_date <= d && b.end_date >= d);
+          return bookings.find(b => b.check_in <= d && b.check_out >= d);
   };
 
   const handleDayClick = (date: Date) => {
@@ -327,8 +327,8 @@ const AdvancedCalendarManager: React.FC<AdvancedCalendarManagerProps> = ({
       const { error } = await supabase.from('bookings').insert({
         property_id: propertyId,
         guest_id: selectedGuest,
-        start_date: startDate,
-        end_date: endDateStr,
+                  check_in: startDate,
+          check_out: endDateStr,
         status: 'confirmada'
       });
       
@@ -426,9 +426,9 @@ const AdvancedCalendarManager: React.FC<AdvancedCalendarManagerProps> = ({
         };
       }),
       ...bookings.map(b => {
-        const [year, month, day] = b.start_date.split('-').map(Number);
-        const startDate = new Date(b.start_date);
-        const endDate = new Date(b.end_date);
+        const [year, month, day] = b.check_in.split('-').map(Number);
+        const startDate = new Date(b.check_in);
+        const endDate = new Date(b.check_out);
         // Calcular duración en días (mínimo 1)
         let days = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
         if (days < 1) days = 1;
@@ -491,8 +491,8 @@ const AdvancedCalendarManager: React.FC<AdvancedCalendarManagerProps> = ({
     const isBlockedDate = blockedDates.some(b => b.date === dateStr);
     const hasSpecialPrice = specialPrices.some(s => s.date === dateStr);
     const hasBooking = bookings.some(b => {
-      const bookingStart = new Date(b.start_date);
-      const bookingEnd = new Date(b.end_date);
+              const bookingStart = new Date(b.check_in);
+        const bookingEnd = new Date(b.check_out);
       return date >= bookingStart && date <= bookingEnd;
     });
     

--- a/src/components/common/AvailabilityCalendar.tsx
+++ b/src/components/common/AvailabilityCalendar.tsx
@@ -9,8 +9,8 @@ interface AvailabilityCalendarProps {
 
 interface Booking {
   id: string;
-  start_date: string;
-  end_date: string;
+  check_in: string;
+  check_out: string;
   status: 'confirmada' | 'pendiente' | 'cancelada';
 }
 
@@ -35,7 +35,7 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({
       // Obtener las reservas de esta propiedad
       const { data: bookingsData, error: bookingsError } = await supabase
         .from('bookings')
-        .select('id, start_date, end_date, status')
+        .select('id, check_in, check_out, status')
         .eq('property_id', propertyId)
         .eq('status', 'confirmada');
 
@@ -57,8 +57,8 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({
     const checkDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
     
     const isBooked = bookings.some(booking => {
-      const startDate = new Date(booking.start_date);
-      const endDate = new Date(booking.end_date);
+      const startDate = new Date(booking.check_in);
+      const endDate = new Date(booking.check_out);
       
       // Normalizar las fechas de reserva a medianoche
       const bookingStart = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());

--- a/src/components/common/RecentBookings.tsx
+++ b/src/components/common/RecentBookings.tsx
@@ -6,8 +6,8 @@ interface Booking {
   id: string;
   property_id: string;
   client_id: string;
-  start_date: string;
-  end_date: string;
+  check_in: string;
+  check_out: string;
   status: 'confirmada' | 'pendiente' | 'cancelada';
   total_price: number;
   created_at: string;
@@ -220,7 +220,7 @@ const RecentBookings: React.FC<RecentBookingsProps> = ({
                   <div className="flex items-center gap-4 text-sm text-gray-500">
                     <div className="flex items-center gap-1">
                       <Calendar className="w-4 h-4" />
-                      <span>{formatDate(booking.start_date)} - {formatDate(booking.end_date)}</span>
+                      <span>{formatDate(booking.check_in)} - {formatDate(booking.check_out)}</span>
                     </div>
                     <div className="flex items-center gap-1">
                       <Euro className="w-4 h-4" />

--- a/src/pages/Bookings/Bookings.tsx
+++ b/src/pages/Bookings/Bookings.tsx
@@ -7,8 +7,8 @@ interface Booking {
   id: string;
   property_id: string;
   client_id: string;
-  start_date: string;
-  end_date: string;
+  check_in: string;
+  check_out: string;
   status: 'confirmada' | 'pendiente' | 'cancelada';
   total_price: number;
 }
@@ -144,7 +144,7 @@ const Bookings = () => {
                   <tr key={booking.id} className="border-b border-gray-100 hover:bg-gray-50 transition">
                     <td className="px-6 py-3 align-middle">{property?.title || 'N/A'}</td>
                     <td className="px-6 py-3 align-middle">{guest?.name || 'N/A'}</td>
-                    <td className="px-6 py-3 align-middle">{new Date(booking.start_date).toLocaleDateString()} - {new Date(booking.end_date).toLocaleDateString()}</td>
+                    <td className="px-6 py-3 align-middle">{new Date(booking.check_in).toLocaleDateString()} - {new Date(booking.check_out).toLocaleDateString()}</td>
                     <td className="px-6 py-3 align-middle">${booking.total_price.toLocaleString()}</td>
                     <td className="px-6 py-3 align-middle">{getStatusChip(booking.status)}</td>
                     <td className="px-6 py-3 align-middle">
@@ -169,8 +169,8 @@ const Bookings = () => {
                   <h3 className="font-bold text-lg truncate">{property?.title || 'Propiedad no encontrada'}</h3>
                   <p className="text-sm text-gray-600">Huésped: {guest?.name || 'Huésped no encontrado'}</p>
                   <div className="mt-3 text-sm">
-                    <p><strong>Desde:</strong> {new Date(booking.start_date).toLocaleDateString()}</p>
-                    <p><strong>Hasta:</strong> {new Date(booking.end_date).toLocaleDateString()}</p>
+                                  <p><strong>Desde:</strong> {new Date(booking.check_in).toLocaleDateString()}</p>
+              <p><strong>Hasta:</strong> {new Date(booking.check_out).toLocaleDateString()}</p>
                   </div>
                   <p className="mt-2 font-semibold">Precio: ${booking.total_price.toLocaleString()}</p>
                 </div>

--- a/src/pages/Dashboard/ClientDashboard.tsx
+++ b/src/pages/Dashboard/ClientDashboard.tsx
@@ -5,8 +5,8 @@ import { supabase } from '../../supabaseClient';
 interface Booking {
   id: string;
   property_id: string;
-  start_date: string;
-  end_date: string;
+  check_in: string;
+  check_out: string;
   total_price: number;
   status?: string;
   property?: { title: string };
@@ -93,9 +93,9 @@ const ClientDashboard: React.FC = () => {
       // Traer reservas con la propiedad asociada
       const { data, error } = await supabase
         .from('bookings')
-        .select('id, property_id, start_date, end_date, total_price, status, properties (title)')
-        .eq('client_id', user.id)
-        .order('start_date', { ascending: false });
+        .select('id, property_id, check_in, check_out, total_price, status, properties (title)')
+        .eq('guest_id', user.id)
+        .order('check_in', { ascending: false });
       if (error) {
         setBookings([]);
       } else {
@@ -172,7 +172,7 @@ const ClientDashboard: React.FC = () => {
                 <li key={b.id} className="py-3">
                   <div className="font-semibold">{b.property?.title || 'Propiedad desconocida'}</div>
                   <div className="text-sm text-gray-600">
-                    {new Date(b.start_date).toLocaleDateString()} - {new Date(b.end_date).toLocaleDateString()}
+                    {new Date(b.check_in).toLocaleDateString()} - {new Date(b.check_out).toLocaleDateString()}
                   </div>
                   <div className="text-sm text-gray-700 mt-1">Coste: <span className="font-bold">{b.total_price} €</span></div>
                   {b.status && <div className="text-xs text-gray-500 mt-1">Estado: {b.status}</div>}

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -191,8 +191,8 @@ const SearchPage = () => {
         // - Y la fecha de fin de la reserva es posterior o igual a la fecha de llegada de la búsqueda
         const { data: bookings, error: bookingsError } = await supabase
           .from('bookings')
-          .select('property_id, start_date, end_date, status')
-          .or(`and(start_date.lte.${checkOutDate},end_date.gte.${checkInDate})`)
+          .select('property_id, check_in, check_out, status')
+          .or(`and(check_in.lte.${checkOutDate},check_out.gte.${checkInDate})`)
           .eq('status', 'confirmada');
 
         if (bookingsError) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Corrected date field names from `start_date`/`end_date` to `check_in`/`check_out` across the application to align with the database schema.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This fixes a bug where property availability filters and detail views were incorrect because the application was querying `start_date` and `end_date` fields, while the database uses `check_in` and `check_out` for booking dates.

**Affected files:**
- `src/components/CalendarManagement/AdvancedCalendarManager.tsx`
- `src/components/common/AvailabilityCalendar.tsx`
- `src/components/common/RecentBookings.tsx`
- `src/pages/Bookings/Bookings.tsx`
- `src/pages/Dashboard/ClientDashboard.tsx`
- `src/pages/Search/SearchPage.tsx`

---
<a href="https://cursor.com/background-agent?bcId=bc-992f866d-704b-4eab-b4ac-7535ec71bf10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-992f866d-704b-4eab-b4ac-7535ec71bf10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>